### PR TITLE
Pagination

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -32,5 +32,22 @@
   "invites": {
     "count": 5
   },
-  "shutdownTimeout": 15000
+  "shutdownTimeout": 15000,
+  "pagination": {
+    "meta": {
+      "location": "header",
+      "count": {
+        "active": false
+      },
+      "last": {
+        "active": false
+      },
+      "first": {
+        "active": false
+      }
+    },
+    "routes": {
+      "include": ["/activities"]
+    }
+  }
 }

--- a/config/development.json
+++ b/config/development.json
@@ -21,6 +21,7 @@
       "routes": {
         "security": true,
         "cors": {
+          "additionalExposedHeaders": ["Link"],
           "origin": ["http://localhost:8080"]
         }
       }

--- a/config/production.json
+++ b/config/production.json
@@ -21,6 +21,7 @@
     "connections": {
       "routes": {
         "cors": {
+          "additionalExposedHeaders": ["Link"],
           "origin": ["https://lift.zone"]
         }
       }

--- a/controllers/activities/list.js
+++ b/controllers/activities/list.js
@@ -7,9 +7,21 @@ module.exports = {
   tags: ['activity'],
   handler: function (request, reply) {
 
-    const result = this.db.activities.for_user(request.auth.credentials.id);
+    const params = Object.assign({ id: request.auth.credentials.id }, request.query);
+    params.page = (params.page - 1) * params.limit;
+    const result = this.db.activities.for_user_count(params).then((activity_count) => {
+
+      request.totalCount = activity_count.count;
+      return this.db.activities.for_user(params);
+    });
 
     return reply(result);
+  },
+  validate: {
+    query: {
+      limit: Joi.number().default(10).min(1).max(100),
+      page: Joi.number().default(0).min(0)
+    }
   },
   response: {
     modify: true,

--- a/db/activities_for_user.sql
+++ b/db/activities_for_user.sql
@@ -6,7 +6,10 @@ FROM
 LEFT JOIN
   activities AS aliases on activities.id = aliases.activity_id
 WHERE
-  activities.user_id = $1
+  activities.user_id = ${id}
   AND
   activities.activity_id is null
 GROUP BY activities.id
+ORDER BY activities.name
+LIMIT ${limit}
+OFFSET ${page}

--- a/db/activities_one_for_user_count.sql
+++ b/db/activities_one_for_user_count.sql
@@ -1,0 +1,8 @@
+SELECT
+  count(activities.id)::integer as count
+FROM
+  activities
+WHERE
+  activities.user_id = ${id}
+  AND
+  activities.activity_id is null

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "good-squeeze": "5.0.1",
     "hapi": "16.1.0",
     "hapi-auth-jwt2": "7.2.4",
+    "hapi-pagination": "1.11.2",
     "hapi-rate-limit": "1.2.4",
     "hoek": "4.1.0",
     "joi": "10.2.0",

--- a/server.js
+++ b/server.js
@@ -31,7 +31,8 @@ if (process.env.NODE_ENV !== 'production') {
 }
 //$lab:coverage:on$
 
-module.exports = server.register([{
+module.exports.db = db;
+module.exports.server = server.register([{
   register: require('good'),
   options: Config.good
 }, {

--- a/server.js
+++ b/server.js
@@ -50,23 +50,7 @@ module.exports.server = server.register([{
   register: require('hapi-auth-jwt2')
 }, {
   register: require('hapi-pagination'),
-  options: {
-    meta: {
-      location: 'header',
-      count: {
-        active: false
-      },
-      last: {
-        active: false
-      },
-      first: {
-        active: false
-      }
-    },
-    routes: {
-      include: ['/activities']
-    }
-  }
+  options: Config.pagination
 }]).then(() => {
 
   server.bind({

--- a/server.js
+++ b/server.js
@@ -48,6 +48,25 @@ module.exports.server = server.register([{
   }
 }, {
   register: require('hapi-auth-jwt2')
+}, {
+  register: require('hapi-pagination'),
+  options: {
+    meta: {
+      location: 'header',
+      count: {
+        active: false
+      },
+      last: {
+        active: false
+      },
+      first: {
+        active: false
+      }
+    },
+    routes: {
+      include: ['/activities']
+    }
+  }
 }]).then(() => {
 
   server.bind({

--- a/test/activities/create.js
+++ b/test/activities/create.js
@@ -2,10 +2,10 @@
 
 const Faker = require('faker');
 
-const Server = require('../../server');
 const Fixtures = require('../fixtures');
 
 const db = Fixtures.db;
+const Server = Fixtures.server;
 
 const lab = exports.lab = require('lab').script();
 const expect = require('code').expect;

--- a/test/activities/get.js
+++ b/test/activities/get.js
@@ -2,10 +2,10 @@
 
 const Faker = require('faker');
 
-const Server = require('../../server');
 const Fixtures = require('../fixtures');
 
 const db = Fixtures.db;
+const Server = Fixtures.server;
 
 const lab = exports.lab = require('lab').script();
 const expect = require('code').expect;

--- a/test/activities/history.js
+++ b/test/activities/history.js
@@ -2,10 +2,10 @@
 
 const Faker = require('faker');
 
-const Server = require('../../server');
 const Fixtures = require('../fixtures');
 
 const db = Fixtures.db;
+const Server = Fixtures.server;
 
 const lab = exports.lab = require('lab').script();
 const expect = require('code').expect;

--- a/test/activities/index.js
+++ b/test/activities/index.js
@@ -56,6 +56,7 @@ describe('GET /activities', () => {
     return server.inject({ method: 'get', url: '/activities', credentials: user1 }).then((res) => {
 
       expect(res.statusCode).to.equal(200);
+      expect(res.headers).to.include('link');
       return res.result;
     }).then((result) => {
 

--- a/test/activities/index.js
+++ b/test/activities/index.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const Server = require('../../server');
 const Fixtures = require('../fixtures');
 
 const db = Fixtures.db;
+const Server = Fixtures.server;
 
 const lab = exports.lab = require('lab').script();
 const expect = require('code').expect;

--- a/test/activities/promote.js
+++ b/test/activities/promote.js
@@ -2,10 +2,10 @@
 
 const Faker = require('faker');
 
-const Server = require('../../server');
 const Fixtures = require('../fixtures');
 
 const db = Fixtures.db;
+const Server = Fixtures.server;
 
 const lab = exports.lab = require('lab').script();
 const expect = require('code').expect;

--- a/test/activities/suggest.js
+++ b/test/activities/suggest.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const Server = require('../../server');
 const Fixtures = require('../fixtures');
 
 const db = Fixtures.db;
+const Server = Fixtures.server;
 
 const lab = exports.lab = require('lab').script();
 const expect = require('code').expect;

--- a/test/admin/users/list.js
+++ b/test/admin/users/list.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const Server = require('../../../server');
 const Fixtures = require('../../fixtures');
 
 const db = Fixtures.db;
+const Server = Fixtures.server;
 
 const lab = exports.lab = require('lab').script();
 const expect = require('code').expect;

--- a/test/auth.js
+++ b/test/auth.js
@@ -1,10 +1,10 @@
 
 'use strict';
 
-const Server = require('../server');
 const Fixtures = require('./fixtures');
 
 const db = Fixtures.db;
+const Server = Fixtures.server;
 
 const lab = exports.lab = require('lab').script();
 const expect = require('code').expect;

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1,10 +1,12 @@
 'use strict';
 
 const Config = require('getconfig');
-const Muckraker = require('muckraker');
 const Faker = require('faker');
 const Bcrypt = require('bcrypt');
 const Moment = require('moment');
+
+module.exports.server = require('../server').server;
+module.exports.db = require('../server').db;
 
 const build = (defaults, attrs, id) => {
 
@@ -22,7 +24,6 @@ const build = (defaults, attrs, id) => {
   return record;
 };
 
-module.exports.db = new Muckraker(Config.db);
 
 module.exports.user = (attrs) => {
 

--- a/test/heartbeat.js
+++ b/test/heartbeat.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Server = require('../server');
+const Server = require('./fixtures').server;
 
 const lab = exports.lab = require('lab').script();
 const expect = require('code').expect;

--- a/test/invites/validate.js
+++ b/test/invites/validate.js
@@ -2,10 +2,10 @@
 
 const Faker = require('faker');
 
-const Server = require('../../server');
 const Fixtures = require('../fixtures');
 
 const db = Fixtures.db;
+const Server = Fixtures.server;
 
 const lab = exports.lab = require('lab').script();
 const expect = require('code').expect;

--- a/test/users/confirm.js
+++ b/test/users/confirm.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const Server = require('../../server');
 const Fixtures = require('../fixtures');
 const Faker = require('faker');
 
 const db = Fixtures.db;
+const Server = Fixtures.server;
 
 const lab = exports.lab = require('lab').script();
 const expect = require('code').expect;

--- a/test/users/index.js
+++ b/test/users/index.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const Server = require('../../server');
 const Fixtures = require('../fixtures');
 const Utils = require('../../lib/utils');
 const Faker = require('faker');
 
 const db = Fixtures.db;
+const Server = Fixtures.server;
 
 const lab = exports.lab = require('lab').script();
 const expect = require('code').expect;

--- a/test/users/invites.js
+++ b/test/users/invites.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const Server = require('../../server');
 const Fixtures = require('../fixtures');
 
 const db = Fixtures.db;
+const Server = Fixtures.server;
 
 const lab = exports.lab = require('lab').script();
 const expect = require('code').expect;

--- a/test/users/login.js
+++ b/test/users/login.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const Server = require('../../server');
 const Fixtures = require('../fixtures');
 
 const db = Fixtures.db;
+const Server = Fixtures.server;
 
 const lab = exports.lab = require('lab').script();
 const expect = require('code').expect;

--- a/test/users/logout.js
+++ b/test/users/logout.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const Server = require('../../server');
 const Fixtures = require('../fixtures');
 const Faker = require('faker');
 
 const db = Fixtures.db;
+const Server = Fixtures.server;
 
 const lab = exports.lab = require('lab').script();
 const expect = require('code').expect;

--- a/test/users/recover.js
+++ b/test/users/recover.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const Server = require('../../server');
 const Fixtures = require('../fixtures');
 const Faker = require('faker');
 const StandIn = require('stand-in');
 const AWS = require('../../lib/aws');
 
 const db = Fixtures.db;
+const Server = Fixtures.server;
 
 const lab = exports.lab = require('lab').script();
 const expect = require('code').expect;

--- a/test/users/reset.js
+++ b/test/users/reset.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const Server = require('../../server');
 const Fixtures = require('../fixtures');
 const Faker = require('faker');
 
 const db = Fixtures.db;
+const Server = Fixtures.server;
 
 const lab = exports.lab = require('lab').script();
 const expect = require('code').expect;

--- a/test/users/signup.js
+++ b/test/users/signup.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const Server = require('../../server');
 const Fixtures = require('../fixtures');
 
 const db = Fixtures.db;
+const Server = Fixtures.server;
 
 const lab = exports.lab = require('lab').script();
 const expect = require('code').expect;

--- a/test/users/validate.js
+++ b/test/users/validate.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const Server = require('../../server');
 const Fixtures = require('../fixtures');
 const StandIn = require('stand-in');
 const AWS = require('../../lib/aws');
 
 const db = Fixtures.db;
+const Server = Fixtures.server;
 
 const lab = exports.lab = require('lab').script();
 const expect = require('code').expect;

--- a/test/workouts/all.js
+++ b/test/workouts/all.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const Server = require('../../server');
 const Fixtures = require('../fixtures');
 
 const db = Fixtures.db;
+const Server = Fixtures.server;
 
 const lab = exports.lab = require('lab').script();
 const expect = require('code').expect;

--- a/test/workouts/create.js
+++ b/test/workouts/create.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const Server = require('../../server');
 const Fixtures = require('../fixtures');
 
 const db = Fixtures.db;
+const Server = Fixtures.server;
 
 const lab = exports.lab = require('lab').script();
 const expect = require('code').expect;

--- a/test/workouts/get.js
+++ b/test/workouts/get.js
@@ -2,10 +2,10 @@
 
 const Faker = require('faker');
 
-const Server = require('../../server');
 const Fixtures = require('../fixtures');
 
 const db = Fixtures.db;
+const Server = Fixtures.server;
 
 const lab = exports.lab = require('lab').script();
 const expect = require('code').expect;

--- a/test/workouts/public.js
+++ b/test/workouts/public.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const Server = require('../../server');
 const Fixtures = require('../fixtures');
 
 const db = Fixtures.db;
+const Server = Fixtures.server;
 
 const lab = exports.lab = require('lab').script();
 const expect = require('code').expect;

--- a/test/workouts/update.js
+++ b/test/workouts/update.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const Server = require('../../server');
 const Fixtures = require('../fixtures');
 const Faker = require('faker');
 const Moment = require('moment');
 
 const db = Fixtures.db;
+const Server = Fixtures.server;
 
 const lab = exports.lab = require('lab').script();
 const expect = require('code').expect;


### PR DESCRIPTION
Adds pagination to the activities route.

Chose not to add it to the workout summary route because this was by design a total list of all workouts with minimal data and we're nowhere near exceeding reasonable payload sizes on that one.

The PR for the client to use this is incoming, and there will be a slight hiccup between the time this is deployed and the time the client is deployed and caches expire. During this time users will only be able to see/edit the first 10 activities they have.