### PR TITLE
fix(package): update @now-ims/hapi-now-auth to version 1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@now-ims/hapi-now-auth": "1.0.1",
+    "@now-ims/hapi-now-auth": "1.0.4",
     "aws-sdk": "2.196.0",
     "bcrypt": "1.0.3",
     "boom": "7.2.0",


### PR DESCRIPTION
Closes #231